### PR TITLE
Refactor liveReport Toggle: adopt method syntax and remove redundant visibility code

### DIFF
--- a/CombatMetrics/CombatMetricsUI.lua
+++ b/CombatMetrics/CombatMetricsUI.lua
@@ -7167,6 +7167,7 @@ local function initLiveReport()
 			SCENE_MANAGER:GetScene("hud"):RemoveFragment(fragment)
 			SCENE_MANAGER:GetScene("hudui"):RemoveFragment(fragment)
 			SCENE_MANAGER:GetScene("siegeBar"):RemoveFragment(fragment)
+			self:SetHidden(true)
 		end
 	end
 

--- a/CombatMetrics/CombatMetricsUI.lua
+++ b/CombatMetrics/CombatMetricsUI.lua
@@ -7154,28 +7154,19 @@ local function initLiveReport()
 
 	local fragment = ZO_HUDFadeSceneFragment:New(liveReport)
 
-	function liveReport.Toggle(liveReport, value)
+	function liveReport:Toggle(value)
 		if value == nil then
-			value = liveReport:IsHidden()
+			value = self:IsHidden()
 		end
 
 		if value == true and SCENE_MANAGER then
 			SCENE_MANAGER:GetScene("hud"):AddFragment(fragment)
 			SCENE_MANAGER:GetScene("hudui"):AddFragment(fragment)
 			SCENE_MANAGER:GetScene("siegeBar"):AddFragment(fragment)
-
-			local currentScene = SCENE_MANAGER.currentScene and SCENE_MANAGER.currentScene.name or ""
-			local isShownForCurrentScene = currentScene == "hud"
-				or currentScene == "hudui"
-				or currentScene == "siegeBar"
-
-			liveReport:SetHidden(not isShownForCurrentScene)
 		else
 			SCENE_MANAGER:GetScene("hud"):RemoveFragment(fragment)
 			SCENE_MANAGER:GetScene("hudui"):RemoveFragment(fragment)
 			SCENE_MANAGER:GetScene("siegeBar"):RemoveFragment(fragment)
-
-			liveReport:SetHidden(true)
 		end
 	end
 


### PR DESCRIPTION
Refactor liveReport Toggle method to use proper Lua method syntax.
Changed from function liveReport.Toggle(liveReport, value) to function liveReport:Toggle(value) and updated references to use self. 
Removed manual visibility checking and SetHidden() calls since the scene manager handles visibility automatically.