### PR TITLE
Fix up the test addon after the suite merge

### DIFF
--- a/CombatMetricsTests/CombatMetricsTests.addon
+++ b/CombatMetricsTests/CombatMetricsTests.addon
@@ -2,7 +2,7 @@
 ## Author: Solinur
 ## Version: 1
 ## AddOnVersion: 1
-## APIVersion: 101046
+## APIVersion: 101050 101051
 ## DependsOn: LibCombat2
 ## OptionalDependsOn: Taneth CombatMetrics
 ## Description: Unit tests for CombatMetrics. Not shipped. Run via run.ps1, or in-game with /taneth.

--- a/CombatMetricsTests/bootstrap.lua
+++ b/CombatMetricsTests/bootstrap.lua
@@ -48,6 +48,7 @@ function CMXTest.RequireCombatMetrics(...)
 	end
 
 	CMXTest.RequireLibCombat("utility.lua")
+	CMXTest.Require("CombatMetrics/lang/en.lua")
 	CMXTest.Require("CombatMetrics/init.lua")
 
 	for i = 1, select("#", ...) do

--- a/CombatMetricsTests/spec_util.lua
+++ b/CombatMetricsTests/spec_util.lua
@@ -5,6 +5,11 @@ end
 
 CMXTest.RequireCombatMetrics("util.lua")
 
+-- In-game CombatMetrics is only an optional dependency, so it may not be there at all.
+if not CombatMetrics then
+	return
+end
+
 local CMXint = CombatMetrics.internal
 local util = CMXint.util
 local cat = util.MainCategories


### PR DESCRIPTION
Three follow-ups from reviewing the merge of #53. All three are test-addon only; nothing shipped changes.

- **API version.** The manifest declared `101046`, older than live (`101050`), so the client treats the addon as out of date and skips it unless out-of-date add-ons are enabled — `/taneth` would find no suite. Now declares `101050 101051`, so it loads on live and PTS alike. Standalone runs were never affected; ESOLua ignores the field.
- **Missing CombatMetrics.** `spec_util.lua` indexed `CombatMetrics.internal` at load while CombatMetrics is only an `OptionalDependsOn`, so installing the test addon without it threw during load instead of skipping. The guard sits *after* `RequireCombatMetrics`, since standalone that call is what loads the addon — guarding at the top of the file would have skipped every test.
- **Localized strings.** `RequireCombatMetrics` never loaded `CombatMetrics/lang/en.lua`, so every `SI_COMBAT_METRICS_*` string was empty standalone. Nothing asserts on one yet, but the first spec that did would have compared `""` against `""` and passed vacuously — the same trap the `GetString` stub caused earlier. Verified by the fix: `GetString(SI_COMBAT_METRICS_DPS)` now returns `DPS` rather than `""`.

Suite still passes: 32/32 in `CombatMetrics`, plus `eso` 176/176.

Not addressed here, since it is a compatibility claim rather than a test concern: `CombatMetrics.addon` itself still declares `101047`, behind live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)