### PR TITLE
fix: correct 'Unkown' to 'Unknown' typo in fight record header

### DIFF
--- a/CombatMetrics/CombatMetrics.lua
+++ b/CombatMetrics/CombatMetrics.lua
@@ -2204,7 +2204,7 @@ local function CheckNumberOfFights()
 end
 
 local function GetFightName(fight)
-	local bigunitname = "Unkown"
+	local bigunitname = "Unknown"
 	local dmgmax = 0
 
 	for k, unitData in pairs(fight.units) do


### PR DESCRIPTION
Fixes issue #55 — corrects 'Unkown' to 'Unknown' in the fight record header (CombatMetrics.lua:2207).

**Change:** local bigunitname = 'Unknown' (was 'Unkown')

**Note:** This is a user-facing UI string shown at the top of the fight record.